### PR TITLE
Fix new tab issue

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,40 +10,21 @@
     "default_popup": "popup.html",
     "default_icon": "icon-34.png"
   },
-  "permissions": [
-    "storage",
-    "tabs",
-    "webNavigation"
-  ],
-  "chrome_url_overrides": {
-    "newtab": "newtab.html"
-  },
+  "permissions": ["storage", "tabs", "webNavigation"],
   "icons": {
     "128": "icon-128.png"
   },
   "content_scripts": [
     {
-      "matches": [
-        "http://*/*",
-        "https://*/*",
-        "<all_urls>"
-      ],
-      "js": [
-        "contentScript.bundle.js"
-      ],
-      "css": [
-        "content.styles.css"
-      ]
+      "matches": ["http://*/*", "https://*/*", "<all_urls>"],
+      "js": ["contentScript.bundle.js"],
+      "css": ["content.styles.css"]
     }
   ],
   "devtools_page": "devtools.html",
   "web_accessible_resources": [
     {
-      "resources": [
-        "content.styles.css",
-        "icon-128.png",
-        "icon-34.png"
-      ],
+      "resources": ["content.styles.css", "icon-128.png", "icon-34.png"],
       "matches": []
     }
   ]


### PR DESCRIPTION
This will fix the issue when a user install the extension and opens a new tab, it was showing a pop-up.

Current behaviour: It will normally open a default tab (no pop-ups)